### PR TITLE
Accept function calls with single arguments in formulas

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -18,7 +18,7 @@ op = _{ add | sub | mul | div }
     div = { "/" }
 
 func = _{ coalesce | min | max }
-list = _{ expr ~ ("," ~ expr)+ }
+list = _{ expr ~ ("," ~ expr)* }
     coalesce = { "COALESCE(" ~ list ~ ")" }
     min = { "MIN(" ~ list ~ ")" }
     max = { "MAX(" ~ list ~ ")" }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,6 +202,8 @@ fn test_function_coalesce() {
             .unwrap(),
         1.
     );
+    let fe = FormulaEngine::<f32>::try_new("COALESCE(#0)").unwrap();
+    assert_eq!(fe.calculate(&HashMap::from([(0, None)])).unwrap(), None);
 }
 
 #[test]
@@ -217,6 +219,12 @@ fn test_function_min() {
         .unwrap(),
         1.
     );
+    let fe = FormulaEngine::<f32>::try_new("MIN(#1)").unwrap();
+    assert_eq!(
+        fe.calculate(&HashMap::from([(1, Some(1.)),])).unwrap(),
+        Some(1.)
+    );
+    assert_eq!(fe.calculate(&HashMap::from([(1, None),])).unwrap(), None);
 }
 
 #[test]
@@ -243,6 +251,12 @@ fn test_function_max() {
         .unwrap(),
         3.
     );
+    let fe = FormulaEngine::<f32>::try_new("MAX(#1)").unwrap();
+    assert_eq!(
+        fe.calculate(&HashMap::from([(1, Some(1.)),])).unwrap(),
+        Some(1.)
+    );
+    assert_eq!(fe.calculate(&HashMap::from([(1, None),])).unwrap(), None);
 }
 
 #[test]


### PR DESCRIPTION
This makes the formula engine more resilient to insignificant issues in the input formulas.